### PR TITLE
Add README with Project Management Process Summary and Index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# OctoAcme Project Management Docs
+
+Welcome to the OctoAcme Project Management documentation hub. This README provides an overview of project management principles and links to all process guides used at OctoAcme.
+
+## Summary of Project Management Processes
+
+OctoAcme’s project management processes are structured to ensure consistent delivery and transparency across all product and service initiatives. The workflow follows a clear lifecycle beginning with project initiation—where business needs, success criteria, stakeholders, and risks are identified—progressing through detailed planning with prioritized backlogs and defined milestones, then moving to day-to-day execution using structured boards and regular cadence meetings. Each project maintains key artifacts such as a one-pager, roadmap, sprint or iteration plans, and a risk register to standardize how work is scoped, tracked, and reviewed throughout the lifecycle.
+
+Central to the process are defined roles and personas that ensure clarity in ownership and responsibilities. The Project Manager (PM) coordinates delivery schedules, risk management, and communications, while the Product Manager (PdM) drives outcome definition and prioritization. Developers implement features, participate in planning, and uphold technical quality, with QA specialists supporting validation and acceptance. These core roles are outlined with clear responsibility sets and goals designed to minimize ambiguity and foster accountability, supported by regular standups, syncs, and stakeholder updates.
+
+Communication and escalation strategies are explicitly embedded into the process framework. The team leverages cadence rituals such as daily standups, weekly delivery syncs, and monthly updates to ensure alignment, surface blockers, and facilitate escalation when issues arise—escalating from team triage to sponsor-level as needed. Stakeholder communication uses standardized templates and a single source of truth for status and updates, while risks are actively tracked and managed via a risk register that is reviewed and updated in sync meetings.
+
+Quality assurance is woven throughout the project lifecycle, from early integration of unit, integration, and end-to-end testing in CI pipelines, to manual QA for feature acceptance and running security scans before releases. Each deployment follows a checklist-driven process to reduce risk, including pre-release criteria, deployment and rollback steps, and post-release verifications. Continuous improvement is promoted via structured retrospectives after each sprint, release, or incident, with action items tracked as backlog issues and reviewed regularly to ensure learnings translate into practice. This comprehensive approach underpins OctoAcme’s ability to deliver reliably, adaptively, and with high quality.
+
+---
+
+## Process Documents Index
+
+- [OctoAcme Project Management Overview](octoacme-project-management-overview.md)
+- [Project Initiation Guide](octoacme-project-initiation.md)
+- [Project Planning](octoacme-project-planning.md)
+- [Execution & Tracking](octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](octoacme-roles-and-personas.md)
+
+---


### PR DESCRIPTION
### Summary

This PR adds a `README.md` to the `docs/` folder, serving as a documentation hub for OctoAcme Project Management processes. The README includes a multi-paragraph summary of our processes, and a complete set of links to all process docs for easy access and onboarding.

Closes #2

### Acceptance Criteria

- [x] Content aligns with existing process docs
- [x] Update improves clarity or closes a documented gap
- [x] Proposed content has been reviewed with stakeholders (if needed)